### PR TITLE
rebase

### DIFF
--- a/src/ctrlm_ir_controller.cpp
+++ b/src/ctrlm_ir_controller.cpp
@@ -39,7 +39,7 @@ using namespace std;
 
 static void* ctrlm_ir_key_monitor_thread(void *data);
 static gboolean ctrlm_ir_retry_input_open(gpointer user_data);
-static int ctrlm_ir_open_key_input_device(string name);
+static int ctrlm_ir_open_key_input_device(std::vector<std::string> names);
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -60,6 +60,8 @@ typedef struct {
 
 #define CTRLM_IR_KEY_MSG_QUEUE_MSG_MAX         (10)
 #define CTRLM_IR_KEY_MSG_QUEUE_MSG_SIZE_MAX    (sizeof(ctrlm_ir_key_queue_msg_thread_poll_t))
+
+#define KEY_INPUT_DEVICE_DEFAULT     "/dev/input/rdk_IR"
 
 #define KEY_INPUT_DEVICE_BASE_DIR    "/dev/input/"
 #define KEY_INPUT_DEVICE_BASE_FILE   "event"
@@ -86,8 +88,7 @@ void ctrlm_ir_controller_t::destroy_instance() {
 }
 
 ctrlm_ir_controller_t::ctrlm_ir_controller_t()
-   : input_device_name_(JSON_STR_VALUE_IR_INPUT_DEVICE_NAME)
-   , last_key_time_(std::make_shared<ctrlm_uint64_db_attr_t>("Last Keypress Time", 0, "", "last_key_time"))
+   : last_key_time_(std::make_shared<ctrlm_uint64_db_attr_t>("Last Keypress Time", 0, "", "last_key_time"))
    , last_key_code_(std::make_shared<ctrlm_uint64_db_attr_t>("Last Keypress Code", CTRLM_KEY_CODE_INVALID, "", "last_key_code"))
    , last_key_time_flush_(0)
    , mask_key_codes_(true)
@@ -99,18 +100,13 @@ ctrlm_ir_controller_t::ctrlm_ir_controller_t()
 
    read_config();
 
-   if (input_device_name_.empty()) {
-      XLOGD_WARN("IR input device name is empty, not starting key monitor thread...");
+   // Create an asynchronous queue to receive incoming messages
+   if (false == ctrlm_utils_message_queue_open(&key_thread_msgq_, CTRLM_IR_KEY_MSG_QUEUE_MSG_MAX, CTRLM_IR_KEY_MSG_QUEUE_MSG_SIZE_MAX)) {
+      XLOGD_ERROR("failed to create message queue to key monitor thread");
    } else {
-
-      // Create an asynchronous queue to receive incoming messages
-      if (false == ctrlm_utils_message_queue_open(&key_thread_msgq_, CTRLM_IR_KEY_MSG_QUEUE_MSG_MAX, CTRLM_IR_KEY_MSG_QUEUE_MSG_SIZE_MAX)) {
-         XLOGD_ERROR("failed to create message queue to key monitor thread");
-      } else {
-         XLOGD_INFO("Starting key monitor thread...");
-         key_thread_.name = "ctrlm_ir_key_mon";
-         ctrlm_utils_thread_create(&key_thread_, ctrlm_ir_key_monitor_thread, this);
-      }
+      XLOGD_INFO("Starting key monitor thread...");
+      key_thread_.name = "ctrlm_ir_key_mon";
+      ctrlm_utils_thread_create(&key_thread_, ctrlm_ir_key_monitor_thread, this);
    }
 }
 
@@ -130,13 +126,29 @@ ctrlm_ir_controller_t::~ctrlm_ir_controller_t() {
 
 bool ctrlm_ir_controller_t::read_config() {
    bool ret = false;
-   ctrlm_config_string_t name("ir.input_device_name");
-   if(name.get_config_value(this->input_device_name_)) {
-      XLOGD_INFO("IR input device name from config file: <%s>", this->input_device_name_.c_str());
+
+   ctrlm_config_string_t configNames("ir.input_device_name");
+   string name_list(JSON_STR_VALUE_IR_INPUT_DEVICE_NAME);
+
+   if (configNames.get_config_value(name_list)) {
+      XLOGD_INFO("Config entry found for IR input device name list: <%s>", name_list.c_str());
       ret = true;
    } else {
-      XLOGD_WARN("Failed to read from config, using IR input device name default: <%s>", this->input_device_name_.c_str());
+      XLOGD_INFO("Config entry not found, using IR input device name list default: <%s>", name_list.c_str());
    }
+   
+   input_device_names_.clear();
+   stringstream ss(name_list);
+   while (ss.good()) {
+      string substr;
+      getline( ss, substr, ',' );
+      if (!substr.empty()) {
+         XLOGD_INFO("Adding IR input device name: <%s>", substr.c_str());
+         input_device_names_.push_back(substr);
+      }
+   }
+
+
    return(ret);
 }
 
@@ -144,8 +156,8 @@ std::string ctrlm_ir_controller_t::name_get(void) {
    return "INFRARED_CONTROLLER";
 }
 
-std::string ctrlm_ir_controller_t::input_device_name_get(void) {
-   return input_device_name_;
+std::vector<std::string> ctrlm_ir_controller_t::input_device_names_get(void) {
+   return input_device_names_;
 }
 
 xr_mq_t ctrlm_ir_controller_t::key_thread_msgq_get() const {
@@ -253,62 +265,72 @@ void ctrlm_ir_controller_t::thread_poll(void *data) {
    ctrlm_utils_queue_msg_push(key_thread_msgq_, (const char *)&msg, sizeof(msg));
 }
 
-static int ctrlm_ir_open_key_input_device(string name) {
-   int fd = -1;
+static int ctrlm_ir_open_key_input_device(vector<string> names) {
    
-   XLOGD_INFO("Searching for IR input device named <%s>", name.c_str());
+   int input_fd = open(KEY_INPUT_DEVICE_DEFAULT, O_RDONLY|O_NONBLOCK);
+   if (input_fd >= 0) {
+      XLOGD_INFO("Successfully opened default IR input device <%s>", KEY_INPUT_DEVICE_DEFAULT);
+      return input_fd;
 
-   if (!name.empty()) {
+   } else {
+      int errsv = errno;
+      XLOGD_WARN("Failed to open default key input device at path <%s>: error = <%d>, <%s>", 
+            KEY_INPUT_DEVICE_DEFAULT, errsv, strerror(errsv));
 
-      string keyInputBaseDir(KEY_INPUT_DEVICE_BASE_DIR);
-      DIR *dir_p = opendir(keyInputBaseDir.c_str());
-      if (NULL == dir_p) {
-         int errsv = errno;
-         XLOGD_ERROR("Failed to open key input device dir at path <%s>: error = <%d>, <%s>", 
-               keyInputBaseDir.c_str(), errsv, strerror(errsv));
-         return -1;
-      }
+      if (!names.empty()) {
 
-      dirent *file_p;
-      while ((file_p = readdir(dir_p)) != NULL) {
-         if (strstr(file_p->d_name, KEY_INPUT_DEVICE_BASE_FILE) != NULL) {
-            //this is one of the event devices, open it and see if it belongs to this MAC
-            string keyInputFilename = keyInputBaseDir + file_p->d_name;
-            int input_fd = open(keyInputFilename.c_str(), O_RDONLY|O_NONBLOCK);
-            if (input_fd < 0) {
-               int errsv = errno;
-               XLOGD_WARN("Failed to open key input device at path <%s>: error = <%d>, <%s>", 
-                     keyInputFilename.c_str(), errsv, strerror(errsv));
-            } else {
-               struct libevdev *evdev = NULL;   
-               int rc = libevdev_new_from_fd(input_fd, &evdev);
-               if (rc < 0) {
-                  XLOGD_ERROR("Failed to init libevdev (%s)", strerror(-rc));   //on failure, rc is negative errno
+         string keyInputBaseDir(KEY_INPUT_DEVICE_BASE_DIR);
+         DIR *dir_p = opendir(keyInputBaseDir.c_str());
+         if (NULL == dir_p) {
+            int errsv = errno;
+            XLOGD_ERROR("Failed to open key input device dir at path <%s>: error = <%d>, <%s>", 
+                  keyInputBaseDir.c_str(), errsv, strerror(errsv));
+            return -1;
+         }
+
+         dirent *file_p;
+         while ((file_p = readdir(dir_p)) != NULL) {
+            if (strstr(file_p->d_name, KEY_INPUT_DEVICE_BASE_FILE) != NULL) {
+               //this is one of the event devices, open it and see if it belongs to this MAC
+               string keyInputFilename = keyInputBaseDir + file_p->d_name;
+               input_fd = open(keyInputFilename.c_str(), O_RDONLY|O_NONBLOCK);
+               if (input_fd < 0) {
+                  int errsv = errno;
+                  XLOGD_WARN("Failed to open key input device at path <%s>: error = <%d>, <%s>", 
+                        keyInputFilename.c_str(), errsv, strerror(errsv));
                } else {
-                  XLOGD_INFO("Input device <%s> name: <%s> ID: bus %#x vendor %#x product %#x, phys = <%s>, unique = <%s>",
-                        keyInputFilename.c_str(),
-                        libevdev_get_name(evdev),libevdev_get_id_bustype(evdev),libevdev_get_id_vendor(evdev),
-                        libevdev_get_id_product(evdev),libevdev_get_phys(evdev),libevdev_get_uniq(evdev));
-               
-                  if (name.compare(libevdev_get_name(evdev)) == 0) {
+                  struct libevdev *evdev = NULL;   
+                  int rc = libevdev_new_from_fd(input_fd, &evdev);
+                  if (rc < 0) {
+                     XLOGD_ERROR("Failed to init libevdev (%s)", strerror(-rc));   //on failure, rc is negative errno
+                  } else {
+                     XLOGD_INFO("Input device <%s> name: <%s> ID: bus %#x vendor %#x product %#x, phys = <%s>, unique = <%s>",
+                           keyInputFilename.c_str(),
+                           libevdev_get_name(evdev),libevdev_get_id_bustype(evdev),libevdev_get_id_vendor(evdev),
+                           libevdev_get_id_product(evdev),libevdev_get_phys(evdev),libevdev_get_uniq(evdev));
+                     
+                     for (auto const &name : names) {
+                        if (name.compare(libevdev_get_name(evdev)) == 0) {
+                           libevdev_free(evdev);
+                           evdev = NULL;
+                           closedir(dir_p);
+                           XLOGD_INFO("Successfully opened IR input device <%s> from NAME <%s>", keyInputFilename.c_str(), name.c_str());
+                           return input_fd;
+                        }
+                     }
+                  }
+                  close(input_fd);
+                  if (NULL != evdev) {
                      libevdev_free(evdev);
                      evdev = NULL;
-                     closedir(dir_p);
-                     XLOGD_INFO("Successfully opened IR input device <%s> from NAME <%s>", keyInputFilename.c_str(), name.c_str());
-                     return input_fd;
                   }
-               }
-               close(input_fd);
-               if (NULL != evdev) {
-                  libevdev_free(evdev);
-                  evdev = NULL;
                }
             }
          }
+         closedir(dir_p);
       }
-      closedir(dir_p);
    }
-   return fd;
+   return -1;
 }
 
 static gboolean ctrlm_ir_retry_input_open(gpointer user_data) {
@@ -340,11 +362,11 @@ void* ctrlm_ir_key_monitor_thread(void *data) {
    char msg[CTRLM_IR_KEY_MSG_QUEUE_MSG_SIZE_MAX];
    xr_mq_t msgq = ir_controller->key_thread_msgq_get();
 
-   string input_device_name = ir_controller->input_device_name_get();
+   vector<string> input_device_names = ir_controller->input_device_names_get();
 
    do {
       if (input_device_fd < 0) {
-         if (0 > (input_device_fd = ctrlm_ir_open_key_input_device(input_device_name))) {
+         if (0 > (input_device_fd = ctrlm_ir_open_key_input_device(input_device_names))) {
             // failed to open the key input device, maybe ctrlm started before the device was created.  Wait a bit and try again.
             if (input_device_retry_cnt < input_device_retry_max) {
                // retry a couple times in case the IR input device hasn't been created yet

--- a/src/ctrlm_ir_controller.h
+++ b/src/ctrlm_ir_controller.h
@@ -55,7 +55,7 @@ public:
 
    void print_status();
 
-   std::string input_device_name_get(void);
+   std::vector<std::string> input_device_names_get(void);
    std::string name_get(void);
 
    /**
@@ -92,7 +92,7 @@ private:
     */
    ctrlm_ir_controller_t();
 
-   std::string                             input_device_name_;
+   std::vector<std::string>                input_device_names_;
 
    std::shared_ptr<ctrlm_uint64_db_attr_t> last_key_time_;
    std::shared_ptr<ctrlm_uint64_db_attr_t> last_key_code_;


### PR DESCRIPTION
…IR input device discovery (#20)

Reason for change: try to open the common udev node for IR key events at /dev/input/rdk_IR, but if that isn't found, then use a list of possible names of IR devices to find the proper input file. This removes the need for product specific settings to provide the proper name until all IR drivers have been updated to use the common udev node.

Test Procedure: IR keypress events printed properly in ctrlm for all platforms.

Risks: Low