### PR TITLE
RDKEMW-3563: Enable ASB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,11 @@ if(ANSI_CODES_DISABLED)
    add_compile_definitions(ANSI_CODES_DISABLED)
 endif()
 
+if(ASB)
+   add_compile_definitions(ASB)
+   target_link_libraries(controlMgr ${ASB_LIBS})
+endif()
+
 if(ASSERT_ON_WRONG_THREAD)
    add_comile_definitions(ASSERT_ON_WRONG_THREAD)
 endif()


### PR DESCRIPTION
Reason for change: Some devices allow for RF4CE Advanced Secure Binding.

Test Procedure: On a device that supports ASB (Broadcom XiOne  Flex 2.0 and Sercomm XiOne) and pair new remote (or re-pair existing remote). Expect to see ASB fail because it's not working correctly, but confirm that it does make the attempt.

Risks: Low

Priority: P1