### PR TITLE
RDKEMW-3605: Remove 'volatile' type qualifier of "binding_in_progress"

### DIFF
--- a/src/rf4ce/ctrlm_rf4ce_network.h
+++ b/src/rf4ce/ctrlm_rf4ce_network.h
@@ -519,11 +519,7 @@ private:
 
    ctrlm_rf4ce_mfg_test_t              mfg_test_;
 
-#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 35
-   volatile gint              binding_in_progress_;
-#else
-   gint                       binding_in_progress_;
-#endif
+   gint                                binding_in_progress_;
    guint                               binding_in_progress_tag_;
    guint                               binding_in_progress_timeout_;
 


### PR DESCRIPTION
Fix ctrlm-main compilation error with glib 2.72.