### PR TITLE
RDKEMW-3835 - [Logging] Add `Invalid firmware version` OTA error code (0x8) mapping in ctrlmgr logs 

### DIFF
--- a/src/ble/hal/blercu/bleservices/gatt/gatt_upgradeservice.cpp
+++ b/src/ble/hal/blercu/bleservices/gatt/gatt_upgradeservice.cpp
@@ -1078,6 +1078,9 @@ void GattUpgradeService::onERRORPacket(const vector<uint8_t> &data)
         case 0x07:
             m_lastError = "Invalid hash error from RCU";
             break;
+        case 0x08:
+            m_lastError = "Invalid FW Version error from RCU";
+            break;
         default:
             m_lastError = "Received unknown error from RCU";
             break;


### PR DESCRIPTION
[Logging] Add `Invalid firmware version` OTA error code (0x8) mapping in ctrlmgr logs