### PR TITLE
rebase

### DIFF
--- a/src/thunder/plugins/ctrlm_thunder_plugin_device_info.cpp
+++ b/src/thunder/plugins/ctrlm_thunder_plugin_device_info.cpp
@@ -104,7 +104,7 @@ bool ctrlm_thunder_plugin_device_info_t::_get_device_type() {
                 this->device_type = CTRLM_DEVICE_TYPE_STB_IP;
             } else if(device_type == "QamIpStb") {
                 this->device_type = CTRLM_DEVICE_TYPE_STB_QAM;
-            } else if(device_type == "IpTv") {
+            } else if(device_type == "IpTv" || device_type == "tv")  {
                 this->device_type = CTRLM_DEVICE_TYPE_TV;
             } else {
                 XLOGD_ERROR("unknown device type <%s>", device_type.c_str());


### PR DESCRIPTION
Reason for change:  DeviceInfo thunder plugin will return "IpTv" for a TV device type instead of "tv".  But to make controlMgr backwards compatible, it should support both "IpTv" and "tv" to denote the device as a TV