### PR TITLE
RDKEMW-3563: Enable ASB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,11 @@ if(ANSI_CODES_DISABLED)
    add_compile_definitions(ANSI_CODES_DISABLED)
 endif()
 
+if(ASB)
+   add_compile_definitions(ASB)
+   target_link_libraries(controlMgr ${ASB_LIBS})
+endif()
+
 if(ASSERT_ON_WRONG_THREAD)
    add_comile_definitions(ASSERT_ON_WRONG_THREAD)
 endif()


### PR DESCRIPTION
Reason for change: RF4CE devices might use Advanced Secure Binding.

Test Procedure: On an RF4CE device, 
curl -H "Authorization: Bearer `WPEFrameworkSecurityUtility |  cut -d '"' -f 4`" --header "Content-Type: application/json"  --request POST -d '{"jsonrpc":"2.0","id":"5","method":"org. rdk.ControlTest.1.setValues","params":{"conversationalMode": 6,"chimeVolume":1,"irCommandRepeats":3,"enableASB":true, "enableOpenChime":false,"enableCloseChime":true,
"enablePrivacyChime":true}}' http://127.0.0.1:9998/jsonrpc

Expect ctrlm to log
CTRLM : ctrlm_main_thread: ASB Enabled Set Values <false>, ASB  Not Supported 
Which simply shows that ASB got defined and still cannot be used at this time

Priority: <P2>

Risks: Low