### PR TITLE
RDKEMW-8354: ctrlm-main crash while holding standby during OTA

### DIFF
--- a/src/ble/hal/blercu/bleservices/gatt/gatt_upgradeservice.cpp
+++ b/src/ble/hal/blercu/bleservices/gatt/gatt_upgradeservice.cpp
@@ -885,7 +885,9 @@ static gboolean timerEvent(gpointer user_data)
         result = us->m_ptr->onTimeout();
     }
 
-    delete us;
+    if (!result) {
+        delete us;
+    }
     return result;
 }
 

--- a/src/ble/hal/blercu/bleservices/gatt/gatt_upgradeservice.cpp
+++ b/src/ble/hal/blercu/bleservices/gatt/gatt_upgradeservice.cpp
@@ -885,6 +885,9 @@ static gboolean timerEvent(gpointer user_data)
         result = us->m_ptr->onTimeout();
     }
 
+    /* GLib timeout repeats on true so it needs this data
+     * only delete when the timer is complete (e.g. returns false)
+     * */
     if (!result) {
         delete us;
     }


### PR DESCRIPTION
Reason for change: crash due to null reference on repeating timer event
Test Procedure: see ticket
Risks: low