### PR TITLE
RDKEMW-12856: throw early error when IRDB provides empty waveforms

### DIFF
--- a/src/ble/ctrlm_ble_network.cpp
+++ b/src/ble/ctrlm_ble_network.cpp
@@ -796,9 +796,10 @@ void ctrlm_obj_network_ble_t::req_process_program_ir_codes(void *data, int size)
             }
       
             if (ble_rcu_interface_) {
-               if (!ble_rcu_interface_->programIrSignalWaveforms(controllers_[controller_id]->ieee_address_get().get_value(), 
+               if (ir_codes.empty()) {
+                  XLOGD_ERROR("Provided IR waveforms are empty!");
+               } else if (!ble_rcu_interface_->programIrSignalWaveforms(controllers_[controller_id]->ieee_address_get().get_value(), 
                                                                 std::move(ir_codes), dqm->vendor_info.rcu_support_bitmask)) {
-
                   XLOGD_ERROR("failed to program IR signal waveforms on remote");
                } else {
                   success = true;


### PR DESCRIPTION
In a request for waveforms an IRDB can return an empty array with a successful status.  This results in a successful call to the plugin method but an asynchronous failure as a status event later.  Its better to return this as an error earlier to the plugin call since we can determine the error condition before sending to the remote.