### PR TITLE
RDKEMW-23354: mics occasionally muted at boot

### DIFF
--- a/src/voice/ctrlm_voice_obj.cpp
+++ b/src/voice/ctrlm_voice_obj.cpp
@@ -3718,18 +3718,25 @@ void ctrlm_voice_t::voice_privacy_disable(bool update_vsdk) {
 }
 
 void ctrlm_voice_t::voice_update_privacy() {
-    if(this->local_mic) {
-        // Read privacy mode state from the DB in case power cycle lost HW GPIO state
-        if(this->device_status[CTRLM_VOICE_DEVICE_MICROPHONE] & CTRLM_VOICE_DEVICE_STATUS_DISABLED) {
-            XLOGD_INFO("voice is disabled, skip privacy");
-        } else {
-            bool privacy_enabled = this->voice_is_privacy_enabled();
-            if(privacy_enabled != this->vsdk_is_privacy_enabled()) {
-                privacy_enabled ? this->voice_privacy_enable(false) : this->voice_privacy_disable(false);
-            }
-        }
-    }
-}
+     if(!this->local_mic) {
+         return;
+     }
+     sem_wait(&this->device_status_semaphore);
+     bool mic_disabled = (this->device_status[CTRLM_VOICE_DEVICE_MICROPHONE] & CTRLM_VOICE_DEVICE_STATUS_DISABLED) != 0;
+     sem_post(&this->device_status_semaphore);
+     // If the mic is disabled, preserve the existing ctrlm/DB privacy state.
+     if(mic_disabled) {
+         XLOGD_INFO("voice is disabled, skip privacy");
+         return;
+     }
+
+     // Refresh ctrlm/DB privacy state from the VSDK after route/input updates.
+     const bool privacy_vsdk  = this->vsdk_is_privacy_enabled();
+     const bool privacy_ctrlm = this->voice_is_privacy_enabled();
+     if(privacy_vsdk != privacy_ctrlm) {
+         privacy_vsdk ? this->voice_privacy_enable(false) : this->voice_privacy_disable(false);
+     }
+ }
 
 void ctrlm_voice_t::voice_device_enable(ctrlm_voice_device_t device, bool db_write, bool *update_routes) {
     sem_wait(&this->device_status_semaphore);

--- a/src/voice/ctrlm_voice_obj.cpp
+++ b/src/voice/ctrlm_voice_obj.cpp
@@ -3723,7 +3723,6 @@ void ctrlm_voice_t::voice_update_privacy() {
         if(this->device_status[CTRLM_VOICE_DEVICE_MICROPHONE] & CTRLM_VOICE_DEVICE_STATUS_DISABLED) {
             XLOGD_INFO("voice is disabled, skip privacy");
         } else {
-            XLOGD_INFO("LLAMA-18353 Reading privacy mode from VSDK");
             bool privacy_enabled = this->voice_is_privacy_enabled();
             if(privacy_enabled != this->vsdk_is_privacy_enabled()) {
                 privacy_enabled ? this->voice_privacy_enable(false) : this->voice_privacy_disable(false);

--- a/src/voice/ctrlm_voice_obj.cpp
+++ b/src/voice/ctrlm_voice_obj.cpp
@@ -588,18 +588,6 @@ bool ctrlm_voice_t::voice_configure_config_file_json(json_t *obj_voice, json_t *
     // Update routes
     this->voice_sdk_update_routes();
 
-    if(this->local_mic) {
-        // Read privacy mode state from the DB in case power cycle lost HW GPIO state
-        if(this->device_status[CTRLM_VOICE_DEVICE_MICROPHONE] & CTRLM_VOICE_DEVICE_STATUS_DISABLED) {
-            XLOGD_INFO("voice is disabled, skip privacy");
-        } else {
-            bool privacy_enabled = this->voice_is_privacy_enabled();
-            if(privacy_enabled != this->vsdk_is_privacy_enabled()) {
-                privacy_enabled ? this->voice_privacy_enable(false) : this->voice_privacy_disable(false);
-            }
-        }
-    }
-
     // Set init message if read from DB
     if(!init.empty()) {
         this->voice_init_set(init.c_str(), false);
@@ -3727,6 +3715,21 @@ void ctrlm_voice_t::voice_privacy_disable(bool update_vsdk) {
       }
       sem_post(&this->device_status_semaphore);
    }
+}
+
+void ctrlm_voice_t::voice_update_privacy() {
+    if(this->local_mic) {
+        // Read privacy mode state from the DB in case power cycle lost HW GPIO state
+        if(this->device_status[CTRLM_VOICE_DEVICE_MICROPHONE] & CTRLM_VOICE_DEVICE_STATUS_DISABLED) {
+            XLOGD_INFO("voice is disabled, skip privacy");
+        } else {
+            XLOGD_INFO("LLAMA-18353 Reading privacy mode from VSDK");
+            bool privacy_enabled = this->voice_is_privacy_enabled();
+            if(privacy_enabled != this->vsdk_is_privacy_enabled()) {
+                privacy_enabled ? this->voice_privacy_enable(false) : this->voice_privacy_disable(false);
+            }
+        }
+    }
 }
 
 void ctrlm_voice_t::voice_device_enable(ctrlm_voice_device_t device, bool db_write, bool *update_routes) {

--- a/src/voice/ctrlm_voice_obj.h
+++ b/src/voice/ctrlm_voice_obj.h
@@ -644,6 +644,7 @@ public:
     bool                  voice_is_privacy_enabled(void);
     void                  voice_privacy_enable(bool update_vsdk);
     void                  voice_privacy_disable(bool update_vsdk);
+    void                  voice_update_privacy();
 
     void                  voice_device_update_set_active(void);
     void                  voice_device_update_set_inactive(void);

--- a/src/voice/ctrlm_voice_obj_generic.cpp
+++ b/src/voice/ctrlm_voice_obj_generic.cpp
@@ -394,6 +394,10 @@ void ctrlm_voice_generic_t::voice_sdk_update_routes() {
     if(!xrsr_route(routes)) {
         XLOGD_ERROR("failed to set routes");
     }
+
+    //Updating routes means updating inputs and outputs, so refresh the privacy setting in case inputs changed
+    this->voice_update_privacy();
+
 }
 
 void ctrlm_voice_generic_t::query_strings_updated() {


### PR DESCRIPTION
Reason for change: Sometimes at boot the privacy setting is checked before the input/output routes are completed so ctrlm cane default to privacy enabled when it should not

Test Procedure: go to settings and confirm that privacy mode is off, microphones are enabled. Reboot and check that privacy is still disabled. Testing will require a lot of reboots, as the original report said this issue might happen only 1 in 10 boots

Risks: low

Priority: P1