### PR TITLE
RDKEMW-23374: toggling privacy mode can cause ctrlm crash

### DIFF
--- a/src/voice/ctrlm_voice_obj.cpp
+++ b/src/voice/ctrlm_voice_obj.cpp
@@ -3731,8 +3731,11 @@ void ctrlm_voice_t::voice_update_privacy() {
          return;
      }
 
-     // Refresh ctrlm/DB privacy state from the VSDK after route/input updates.
-     const bool privacy_vsdk  = this->vsdk_is_privacy_enabled();
+     bool privacy_vsdk = true;
+     if(!xrsr_privacy_mode_get(&privacy_vsdk)) {
+         XLOGD_ERROR("error getting privacy mode, leaving ctrlm privacy unchanged");
+         return;
+     }
      const bool privacy_ctrlm = this->voice_is_privacy_enabled();
      if(privacy_vsdk != privacy_ctrlm) {
          privacy_vsdk ? this->voice_privacy_enable(false) : this->voice_privacy_disable(false);

--- a/src/voice/ctrlm_voice_obj.cpp
+++ b/src/voice/ctrlm_voice_obj.cpp
@@ -588,18 +588,6 @@ bool ctrlm_voice_t::voice_configure_config_file_json(json_t *obj_voice, json_t *
     // Update routes
     this->voice_sdk_update_routes();
 
-    if(this->local_mic) {
-        // Read privacy mode state from the DB in case power cycle lost HW GPIO state
-        if(this->device_status[CTRLM_VOICE_DEVICE_MICROPHONE] & CTRLM_VOICE_DEVICE_STATUS_DISABLED) {
-            XLOGD_INFO("voice is disabled, skip privacy");
-        } else {
-            bool privacy_enabled = this->voice_is_privacy_enabled();
-            if(privacy_enabled != this->vsdk_is_privacy_enabled()) {
-                privacy_enabled ? this->voice_privacy_enable(false) : this->voice_privacy_disable(false);
-            }
-        }
-    }
-
     // Set init message if read from DB
     if(!init.empty()) {
         this->voice_init_set(init.c_str(), false);
@@ -829,6 +817,7 @@ bool ctrlm_voice_t::voice_configure(json_t *settings, bool db_write) {
                         } else if(!privacy_enabled) {
                             this->voice_privacy_enable(true);
                         }
+                        update_routes = false;
                     } else {
                         if(enable) {
                             this->voice_device_enable(CTRLM_VOICE_DEVICE_MICROPHONE, db_write, &update_routes);
@@ -3728,6 +3717,27 @@ void ctrlm_voice_t::voice_privacy_disable(bool update_vsdk) {
       sem_post(&this->device_status_semaphore);
    }
 }
+
+void ctrlm_voice_t::voice_update_privacy() {
+     if(!this->local_mic) {
+         return;
+     }
+     sem_wait(&this->device_status_semaphore);
+     bool mic_disabled = (this->device_status[CTRLM_VOICE_DEVICE_MICROPHONE] & CTRLM_VOICE_DEVICE_STATUS_DISABLED) != 0;
+     sem_post(&this->device_status_semaphore);
+     // If the mic is disabled, preserve the existing ctrlm/DB privacy state.
+     if(mic_disabled) {
+         XLOGD_INFO("voice is disabled, skip privacy");
+         return;
+     }
+
+     // Refresh ctrlm/DB privacy state from the VSDK after route/input updates.
+     const bool privacy_vsdk  = this->vsdk_is_privacy_enabled();
+     const bool privacy_ctrlm = this->voice_is_privacy_enabled();
+     if(privacy_vsdk != privacy_ctrlm) {
+         privacy_vsdk ? this->voice_privacy_enable(false) : this->voice_privacy_disable(false);
+     }
+ }
 
 void ctrlm_voice_t::voice_device_enable(ctrlm_voice_device_t device, bool db_write, bool *update_routes) {
     sem_wait(&this->device_status_semaphore);

--- a/src/voice/ctrlm_voice_obj.h
+++ b/src/voice/ctrlm_voice_obj.h
@@ -641,15 +641,15 @@ public:
     void                  voice_session_set_active(ctrlm_voice_device_t device);
     void                  voice_session_set_inactive(ctrlm_voice_device_t device);
 
-    bool                  voice_is_privacy_enabled(void);
-    void                  voice_privacy_enable(bool update_vsdk);
-    void                  voice_privacy_disable(bool update_vsdk);
-
     void                  voice_device_update_set_active(void);
     void                  voice_device_update_set_inactive(void);
 
     void                  voice_device_enable(ctrlm_voice_device_t device, bool db_update, bool *update_routes);
     void                  voice_device_disable(ctrlm_voice_device_t device, bool db_update, bool *update_routes);
+    bool                  voice_is_privacy_enabled(void);
+    void                  voice_privacy_enable(bool update_vsdk);
+    void                  voice_privacy_disable(bool update_vsdk);
+    void                  voice_update_privacy();
 
     protected:
     // STB Data

--- a/src/voice/ctrlm_voice_obj_generic.cpp
+++ b/src/voice/ctrlm_voice_obj_generic.cpp
@@ -394,6 +394,10 @@ void ctrlm_voice_generic_t::voice_sdk_update_routes() {
     if(!xrsr_route(routes)) {
         XLOGD_ERROR("failed to set routes");
     }
+
+    //Updating routes means updating inputs and outputs, so refresh the privacy setting in case inputs changed
+    this->voice_update_privacy();
+
 }
 
 void ctrlm_voice_generic_t::query_strings_updated() {


### PR DESCRIPTION
Reason for change: We don't want to crash ctrlm

Test Procedure: using side panel button or UI toggle privacy mode repeatedly. Check ctrlm_log.txt for
"XRSR : xrsr_xraudio_keyword_detect_error: source " which indicates that an error occurred.
From there, confirm that the HAL is reloaded, state recovers, ctrlm does not crash

Risks: Low