### PR TITLE
RDKEMW-23374 : Control Manager can boot showing incorrect privacy

### DIFF
--- a/src/voice/ctrlm_voice_obj.cpp
+++ b/src/voice/ctrlm_voice_obj.cpp
@@ -156,7 +156,6 @@ ctrlm_voice_t::ctrlm_voice_t() {
         this->local_mic_tap                   = false;
         this->local_mic_disable_via_privacy   = false;
     }
-    this->local_mic_routes_configured       = false;
 
     if(ctrlm_file_exists(BEEP_ON_KWD_FILE_VD)) {
         this->beep_on_kwd_file            = BEEP_ON_KWD_SAP_VD;
@@ -344,8 +343,8 @@ bool ctrlm_voice_t::vsdk_is_privacy_enabled(void) {
    bool privacy = true;
 
    if(!xrsr_privacy_mode_get(&privacy)) {
-      XLOGD_ERROR("error getting privacy mode, defaulting to ON");
-      privacy = true;
+      XLOGD_ERROR("error getting privacy mode, defaulting to saved state");
+      privacy = this->voice_is_privacy_enabled();
    }
 
    return privacy;
@@ -759,23 +758,32 @@ bool ctrlm_voice_t::voice_configure(json_t *settings, bool db_write) {
                 }
             }
         }
+        // the urls are present on every configure call, so only re-route when one actually changes
         if(conf.config_value_get("urlAll", url)) {
+            if(this->prefs.server_url_src_mic_tap != url || this->prefs.server_url_src_ptt != url || this->prefs.server_url_src_ff != url) {
+                update_routes = true;
+            }
             this->prefs.server_url_src_mic_tap = url;
             this->prefs.server_url_src_ptt     = url;
             this->prefs.server_url_src_ff      = std::move(url);
-            update_routes = true;
         }
         if(conf.config_value_get("urlPtt", url)) {
+            if(this->prefs.server_url_src_ptt != url) {
+                update_routes = true;
+            }
             this->prefs.server_url_src_ptt = std::move(url);
-            update_routes = true;
         }
         if(conf.config_value_get("urlHf", url)) {
+            if(this->prefs.server_url_src_ff != url) {
+                update_routes = true;
+            }
             this->prefs.server_url_src_ff  = std::move(url);
-            update_routes = true;
         }
         if(conf.config_value_get("urlMicTap", url)) {
+            if(this->prefs.server_url_src_mic_tap != url) {
+                update_routes = true;
+            }
             this->prefs.server_url_src_mic_tap  = std::move(url);
-            update_routes = true;
         }
         if(conf.config_value_get("prv", prv_enabled)) {
             this->prefs.par_voice_enabled = prv_enabled;
@@ -816,9 +824,6 @@ bool ctrlm_voice_t::voice_configure(json_t *settings, bool db_write) {
                             }
                         } else if(!privacy_enabled) {
                             this->voice_privacy_enable(true);
-                        }
-                        if(this->local_mic_routes_configured) {
-                            update_routes = false;
                         }
                     } else {
                         if(enable) {

--- a/src/voice/ctrlm_voice_obj.cpp
+++ b/src/voice/ctrlm_voice_obj.cpp
@@ -155,8 +155,8 @@ ctrlm_voice_t::ctrlm_voice_t() {
         this->local_mic                       = false;
         this->local_mic_tap                   = false;
         this->local_mic_disable_via_privacy   = false;
-        
     }
+    this->local_mic_routes_configured       = false;
 
     if(ctrlm_file_exists(BEEP_ON_KWD_FILE_VD)) {
         this->beep_on_kwd_file            = BEEP_ON_KWD_SAP_VD;
@@ -588,18 +588,6 @@ bool ctrlm_voice_t::voice_configure_config_file_json(json_t *obj_voice, json_t *
     // Update routes
     this->voice_sdk_update_routes();
 
-    if(this->local_mic) {
-        // Read privacy mode state from the DB in case power cycle lost HW GPIO state
-        if(this->device_status[CTRLM_VOICE_DEVICE_MICROPHONE] & CTRLM_VOICE_DEVICE_STATUS_DISABLED) {
-            XLOGD_INFO("voice is disabled, skip privacy");
-        } else {
-            bool privacy_enabled = this->voice_is_privacy_enabled();
-            if(privacy_enabled != this->vsdk_is_privacy_enabled()) {
-                privacy_enabled ? this->voice_privacy_enable(false) : this->voice_privacy_disable(false);
-            }
-        }
-    }
-
     // Set init message if read from DB
     if(!init.empty()) {
         this->voice_init_set(init.c_str(), false);
@@ -828,6 +816,9 @@ bool ctrlm_voice_t::voice_configure(json_t *settings, bool db_write) {
                             }
                         } else if(!privacy_enabled) {
                             this->voice_privacy_enable(true);
+                        }
+                        if(this->local_mic_routes_configured) {
+                            update_routes = false;
                         }
                     } else {
                         if(enable) {
@@ -3727,6 +3718,30 @@ void ctrlm_voice_t::voice_privacy_disable(bool update_vsdk) {
       }
       sem_post(&this->device_status_semaphore);
    }
+}
+
+void ctrlm_voice_t::voice_update_privacy() {
+    if(!this->local_mic) {
+        return;
+    }
+    sem_wait(&this->device_status_semaphore);
+    bool mic_disabled = (this->device_status[CTRLM_VOICE_DEVICE_MICROPHONE] & CTRLM_VOICE_DEVICE_STATUS_DISABLED) != 0;
+    sem_post(&this->device_status_semaphore);
+    // If the mic is disabled, preserve the existing ctrlm/DB privacy state.
+    if(mic_disabled) {
+        XLOGD_INFO("voice is disabled, skip privacy");
+        return;
+    }
+
+    bool privacy_vsdk = true;
+    if(!xrsr_privacy_mode_get(&privacy_vsdk)) {
+        XLOGD_ERROR("error getting privacy mode, leaving ctrlm privacy unchanged");
+        return;
+    }
+    const bool privacy_ctrlm = this->voice_is_privacy_enabled();
+    if(privacy_vsdk != privacy_ctrlm) {
+        privacy_vsdk ? this->voice_privacy_enable(false) : this->voice_privacy_disable(false);
+    }
 }
 
 void ctrlm_voice_t::voice_device_enable(ctrlm_voice_device_t device, bool db_write, bool *update_routes) {

--- a/src/voice/ctrlm_voice_obj.cpp
+++ b/src/voice/ctrlm_voice_obj.cpp
@@ -3729,9 +3729,11 @@ void ctrlm_voice_t::voice_update_privacy() {
     if(!this->local_mic) {
         return;
     }
+
     sem_wait(&this->device_status_semaphore);
     bool mic_disabled = (this->device_status[CTRLM_VOICE_DEVICE_MICROPHONE] & CTRLM_VOICE_DEVICE_STATUS_DISABLED) != 0;
     sem_post(&this->device_status_semaphore);
+
     // If the mic is disabled, preserve the existing ctrlm/DB privacy state.
     if(mic_disabled) {
         XLOGD_INFO("voice is disabled, skip privacy");
@@ -3743,6 +3745,17 @@ void ctrlm_voice_t::voice_update_privacy() {
         XLOGD_ERROR("error getting privacy mode, leaving ctrlm privacy unchanged");
         return;
     }
+
+    // Mic state can change concurrently; don't update ctrlm/DB privacy while the mic is disabled.
+    sem_wait(&this->device_status_semaphore);
+    mic_disabled = (this->device_status[CTRLM_VOICE_DEVICE_MICROPHONE] & CTRLM_VOICE_DEVICE_STATUS_DISABLED) != 0;
+    sem_post(&this->device_status_semaphore);
+
+    if(mic_disabled) {
+        XLOGD_INFO("voice is disabled, skip privacy");
+        return;
+    }
+
     const bool privacy_ctrlm = this->voice_is_privacy_enabled();
     if(privacy_vsdk != privacy_ctrlm) {
         privacy_vsdk ? this->voice_privacy_enable(false) : this->voice_privacy_disable(false);

--- a/src/voice/ctrlm_voice_obj.h
+++ b/src/voice/ctrlm_voice_obj.h
@@ -668,7 +668,6 @@ public:
     bool                     local_mic;
     bool                     local_mic_tap;
     bool                     local_mic_disable_via_privacy;
-    bool                     local_mic_routes_configured;
     const char *             beep_on_kwd_file;
     bool                     beep_on_kwd_supported;
     bool                     ocsp_verify_stapling;

--- a/src/voice/ctrlm_voice_obj.h
+++ b/src/voice/ctrlm_voice_obj.h
@@ -644,6 +644,7 @@ public:
     bool                  voice_is_privacy_enabled(void);
     void                  voice_privacy_enable(bool update_vsdk);
     void                  voice_privacy_disable(bool update_vsdk);
+    void                  voice_update_privacy(void);
 
     void                  voice_device_update_set_active(void);
     void                  voice_device_update_set_inactive(void);
@@ -667,6 +668,7 @@ public:
     bool                     local_mic;
     bool                     local_mic_tap;
     bool                     local_mic_disable_via_privacy;
+    bool                     local_mic_routes_configured;
     const char *             beep_on_kwd_file;
     bool                     beep_on_kwd_supported;
     bool                     ocsp_verify_stapling;

--- a/src/voice/ctrlm_voice_obj_generic.cpp
+++ b/src/voice/ctrlm_voice_obj_generic.cpp
@@ -166,6 +166,7 @@ void ctrlm_voice_generic_t::voice_sdk_update_routes() {
     ERR_CHK(safec_rc);
 
     bool networked_standby_supported = ctrlm_is_networked_standby_supported();
+    this->local_mic_routes_configured = (this->local_mic && this->local_mic_disable_via_privacy);
 
     // iterate over source to url mapping
     for(int j = 0; j < XRSR_SRC_INVALID; j++) {
@@ -394,6 +395,10 @@ void ctrlm_voice_generic_t::voice_sdk_update_routes() {
     if(!xrsr_route(routes)) {
         XLOGD_ERROR("failed to set routes");
     }
+
+    //Updating routes means updating inputs and outputs, so refresh the privacy setting in case inputs changed
+    this->voice_update_privacy();
+
 }
 
 void ctrlm_voice_generic_t::query_strings_updated() {

--- a/src/voice/ctrlm_voice_obj_generic.cpp
+++ b/src/voice/ctrlm_voice_obj_generic.cpp
@@ -166,7 +166,6 @@ void ctrlm_voice_generic_t::voice_sdk_update_routes() {
     ERR_CHK(safec_rc);
 
     bool networked_standby_supported = ctrlm_is_networked_standby_supported();
-    this->local_mic_routes_configured = (this->local_mic && this->local_mic_disable_via_privacy);
 
     // iterate over source to url mapping
     for(int j = 0; j < XRSR_SRC_INVALID; j++) {


### PR DESCRIPTION
state

Reason for change : ctrlm must reflect the actual privacy state instead of sometimes defaulting to ON when the user did not set it

Test procedure : set some privacy state, boot, confirm that privacy is either on or off depending on what was set, repeat, changing the desired state sometimes